### PR TITLE
Added support for user folder in %LOCALAPPDATA%

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -31,6 +31,7 @@
 #define JAP_DIR "JAP"
 
 // Subdirs in the User dir returned by GetUserPath(D_USER_IDX)
+#define CITRA_LOCAL "Citra local"
 #define CONFIG_DIR "config"
 #define GAMECONFIG_DIR "game_config"
 #define MAPS_DIR "maps"

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -154,6 +154,7 @@ std::string GetBundleDirectory();
 
 #ifdef _WIN32
 std::string& GetExeDirectory();
+std::string& AppDataLocalDirectory();
 #endif
 
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename);


### PR DESCRIPTION
This PR changes the default location of the "user" folder on Windows, to AppData/Local.
If a "user" folder in the same folder of the executable, then citra will run in "portable mode".

This breaks definitely support with Windows XP or older, this also defaults windows version to 0x600 (Windows Vista).

Please test it.