### PR TITLE
Move to SDL2-2.0.5

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -19,8 +19,8 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
 
     if [ ! -e $HOME/.local/lib/libSDL2.la ]; then
         echo "SDL2 not found in cache, get and build it..."
-        wget http://libsdl.org/release/SDL2-2.0.4.tar.gz -O - | tar xz
-        cd SDL2-2.0.4
+        wget http://libsdl.org/release/SDL2-2.0.5.tar.gz -O - | tar xz
+        cd SDL2-2.0.5
         ./configure --prefix=$HOME/.local
         make -j4 && make install
     else

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if (ENABLE_SDL2)
     if (CITRA_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if (MSVC14 AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.0.4")
+            set(SDL2_VER "SDL2-2.0.5")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable CITRA_USE_BUNDLED_SDL2 and provide your own.")
         endif()


### PR DESCRIPTION
Switch to SDL2-2.0.5

Someone needs to commit the binaries to https://github.com/citra-emu/ext-windows-bin/ for this to work.

The .7z can be created executing:
wget https://libsdl.org/release/SDL2-devel-2.0.5-VC.zip ; unzip SDL2-devel-2.0.5-VC.zip ;  7z a -t7z -m0=lzma -mx=9 -mfb=64 -md=32m -ms=on SDL2-2.0.5.7z SDL2-2.0.5